### PR TITLE
41 read an env file for the url api in the dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 private*
 .env
+/src/dashboard/www/public_html/js/env.js
 /wd/
-/.idea/
 
 # History files
 .Rhistory

--- a/src/dashboard/www/public_html/js/env_example.js
+++ b/src/dashboard/www/public_html/js/env_example.js
@@ -1,0 +1,4 @@
+export function get_api_url() {
+    return "http://127.0.0.1:8000/api";
+  }
+  

--- a/src/dashboard/www/public_html/js/main.js
+++ b/src/dashboard/www/public_html/js/main.js
@@ -1,4 +1,6 @@
-var API_URL = "http://127.0.0.1:8000/api";
+import * as _env from './env.js?version=0.3'
+
+var API_URL = _env.get_api_url()
 
 import * as _api from './api.js?version=0.98'
 import * as _init from './init.js?version=0.24'
@@ -8,6 +10,7 @@ import * as _popMap from './population_map.js?version=0.98'
 import * as _popPyramid from './population_pyramid.js?version=0.34'
 import * as _migrationProb from './migration_probabilities.js?version=2.06'
 import * as _popPprobabilities from './pop_probabilities.js?version=0.22'
+
 
 //_utils.progressMenuOn();
 


### PR DESCRIPTION
The main.js contains at the beginning a declaration of the API_URL.
I want the API_URL to be stored in an .env file for smooth deployment on the server.

I have found a way to have to do it by creating a env.js (see the [env_example.js](https://github.com/OxfordDemSci/UkraineNowPop/blob/41-read-an-env-file-for-the-url-api-in-the-dashboard/src/dashboard/www/public_html/js/env_example.js)) and calling it in main.js.

```
import * as _env from './env.js?version=0.3'
var API_URL = _env.get_api_url()
```

is that correct and the best way to do it?