### PR TITLE
51 prepare facebook and instagram data for n mixture model

### DIFF
--- a/src/1_pop_data/10_daily_audience.py
+++ b/src/1_pop_data/10_daily_audience.py
@@ -23,7 +23,7 @@ os.makedirs(out_dir, exist_ok=True)
 #---- input data ----#
 
 # agesex demographic groups
-agesex = ['T_18Plus']
+agesex = ['T_13Plus']
 # \
 # ['F_13Plus', 'F_18Plus', 'F_20Plus', 'F_13_19', 'F_15_49', 'F_15_64', 'F_18_34', 'F_20_29', 'F_30_39', 'F_40_49', 'F_50_59', 'F_60Plus', 'F_65Plus',
 #     'M_13Plus', 'M_18Plus', 'M_20Plus', 'M_13_19', 'M_15_49', 'M_15_64', 'M_18_34', 'M_20_29', 'M_30_39', 'M_40_49', 'M_50_59', 'M_60Plus', 'M_65Plus',
@@ -31,25 +31,25 @@ agesex = ['T_18Plus']
 
 
 # end date
-date_end = '2022-04-01'
+date_start = '2022-02-26'
+date_end = '2023-02-25'
+
+country = 'UA'
 
 #---- daily audience ----#
 for platform in ['facebook', 'instagram']:
     # platform = 'facebook'
+    date_start_obj = datetime.strptime(date_start, '%Y-%m-%d')
+    date_start_obj += timedelta(days=2)
+    date_start_obj = date_start_obj.strftime('%Y-%m-%d')
 
-    outfile = os.path.join(out_dir, 'ukr_'+platform+'_adm1_audience.csv')
-
-
-    date_start = '2022-02-26'
-    audience_existing = None
-
-
+    outfile = os.path.join(out_dir, country.lower() + '_'+platform+'_audience.csv')
     meta_key = pyidp.query_api(
         endpoint='query_clean',            
         args = {'date_start': date_start,
-                    'date_end': '2022-02-27',
+                    'date_end': date_start_obj,
                     'platform': 'facebook',
-                    'country': 'UA',
+                    'country': country,
                     'geo_level': 'regions',
                     'language_name': 'all'})
 
@@ -58,7 +58,7 @@ for platform in ['facebook', 'instagram']:
             date_start=date_start,
             date_end= date_end,
             platform=platform,
-            country='UA',
+            country=country,
             geo_level='regions',
             geo_keys=meta_key['geo_key'].unique().tolist(),
             agesex= agesex,

--- a/src/1_pop_data/11_process_daily_audience.R
+++ b/src/1_pop_data/11_process_daily_audience.R
@@ -53,8 +53,8 @@ convert_audience_to_md <- function(social_media, metric) {
       n_obs = n_distinct(day_of_week),
       day_of_week_obs = paste(day_of_week, collapse = ",")) 
 
-  saveRDS(social_media_reshape_array, paste0(env$out_dir,'model/', 'model_data/', platform, '_md.rds'))
-  saveRDS(n_obs_per_week, paste0(env$out_dir,'model/', 'model_data/', platform, '_md_missing.rds'))
+  saveRDS(social_media_reshape_array, paste0(env$out_dir,'population_proxy/', 'model_data/', platform, '_md.rds'))
+  saveRDS(n_obs_per_week, paste0(env$out_dir,'population_proxy/', 'model_data/', platform, '_md_missing.rds'))
 
   return(list('md'=social_media_reshape_array, 'md_missing'=n_obs_per_week))
 }

--- a/src/1_pop_data/11_process_daily_audience.R
+++ b/src/1_pop_data/11_process_daily_audience.R
@@ -1,4 +1,4 @@
-# Convert the Facebook and Instagram daily audience data from a long format to a 3D array [week_num, geo_name, day_of_week]
+# Convert the Facebook and Instagram daily audience data from a long format to a 3D array  [week, oblast, day_of_week]
 # suitable for use with the N-mixture model.
 
 # Libraries
@@ -8,7 +8,7 @@ library(tidyverse)
 env <- new.env()
 source(here::here('.env'), local=env)
 
-#' Convert the daily audience data from a long format to a 3D array [week_num, geo_name, day_of_week]
+#' Convert the daily audience data from a long format to a 3D array  [week, oblast, day_of_week]
 #'
 #' @param social_media a data frame containing the audience data.
 #' @param metric the name of the column containing the audience values ('dau', 'mau_lower', 'mau_upper')

--- a/src/1_pop_data/11_process_daily_audience.R
+++ b/src/1_pop_data/11_process_daily_audience.R
@@ -1,0 +1,70 @@
+# Convert the Facebook and Instagram daily audience data from a long format to a 3D array [week_num, geo_name, day_of_week]
+# suitable for use with the N-mixture model.
+
+# Libraries
+library(tidyverse)
+
+# Working directory
+env <- new.env()
+source(here::here('.env'), local=env)
+
+#' Convert the daily audience data from a long format to a 3D array [week_num, geo_name, day_of_week]
+#'
+#' @param social_media a data frame containing the audience data.
+#' @param metric the name of the column containing the audience values ('dau', 'mau_lower', 'mau_upper')
+#' @export
+
+convert_audience_to_md <- function(social_media, metric) {
+
+  social_media <- social_media |>
+    rename(audience=metric) |> 
+    select(collection_date, audience, agesex, platform, geo_name)
+
+  # compute the indices: day of week and week_num
+  social_media$collection_date <- as.Date(social_media$collection_date)
+  social_media$day_of_week <- format(social_media$collection_date, "%u")
+  social_media$week <- paste0(as.numeric(format(social_media$collection_date, "%y")) ,as.numeric(format(social_media$collection_date, "%W")))
+  social_media$week_num <- as.numeric((as_factor(social_media$week)))
+
+  # fill with NAs the missing combinations of geo_name, day_of_week and week_num
+  social_media <- social_media |>
+    complete(geo_name, day_of_week, week_num)
+
+  # reshape the audience data to a 3D array [week_num, geo_name, day_of_week]
+  social_media_reshape <- social_media |> 
+    select(geo_name, audience, day_of_week, week_num) |> 
+    complete(geo_name, day_of_week, week_num)|> 
+    pivot_wider(names_from = geo_name, values_from = audience) |> 
+    arrange(week_num, day_of_week) |>
+    select(-week_num) |> 
+    group_split(day_of_week, .keep=F)
+
+  social_media_reshape_array <- lapply(social_media_reshape, as.matrix)
+  social_media_reshape_array <- array(unlist(social_media_reshape_array), 
+                                      dim=c(n_distinct(social_media$week_num), n_distinct(social_media$geo_name), n_distinct(social_media$day_of_week)))
+  
+  # Compute the number of days per week per geo_name that have no audience 
+  # and concatenate the corresponding day of the week indices
+
+  n_obs_per_week <- social_media |> 
+    filter(!is.na(audience)) |>
+    group_by(week_num, geo_name) |> 
+    summarise(
+      n_obs = n_distinct(day_of_week),
+      day_of_week_obs = paste(day_of_week, collapse = ",")) 
+
+  saveRDS(social_media_reshape_array, paste0(env$out_dir,'model/', 'model_data/', platform, '_md.rds'))
+  saveRDS(n_obs_per_week, paste0(env$out_dir,'model/', 'model_data/', platform, '_md_missing.rds'))
+
+  return(list('md'=social_media_reshape_array, 'md_missing'=n_obs_per_week))
+}
+
+
+# Convert the audience data for each platform to a 3D array (md)
+for (platform in c('facebook', 'instagram')) {
+  platform_audience <- read_csv(paste0(env$out_dir,'population_proxy/', 'social_media_audience/', 'ua_', platform, '_audience.csv')) 
+  out <- convert_audience_to_md(social_media=platform_audience, metric='dau')
+}
+
+
+

--- a/src/1_pop_data/11_process_daily_audience.R
+++ b/src/1_pop_data/11_process_daily_audience.R
@@ -42,7 +42,7 @@ convert_audience_to_md <- function(social_media, metric) {
   social_media_reshape_array <- lapply(social_media_reshape, as.matrix)
   social_media_reshape_array <- array(unlist(social_media_reshape_array), 
                                       dim=c(n_distinct(social_media$week_num), n_distinct(social_media$geo_name), n_distinct(social_media$day_of_week)))
-  
+
   # Compute the number of days per week per geo_name that have no audience 
   # and concatenate the corresponding day of the week indices
 
@@ -51,9 +51,26 @@ convert_audience_to_md <- function(social_media, metric) {
     group_by(week_num, geo_name) |> 
     summarise(
       n_obs = n_distinct(day_of_week),
-      day_of_week_obs = paste(day_of_week, collapse = ",")) 
+      day_of_week_obs = paste(day_of_week, collapse = ",")) |> 
+    ungroup() |>
+    complete(week_num, geo_name, fill = list(n_obs = 0, day_of_week_obs = NA))
+  
+  n_obs_per_week_matrix <- n_obs_per_week |> 
+    ungroup() |>
+    select(week_num, geo_name, n_obs) |> 
+    pivot_wider(names_from = geo_name, values_from = n_obs) |> 
+    arrange(week_num) |> 
+    select(-week_num) |> 
+    as.matrix()
+    
+    md <- list(
+      y = social_media_reshape_array,
+      T = n_distinct(social_media$week_num),
+      I = n_distinct(social_media$geo_name),
+      M = n_obs_per_week_matrix
+    )
 
-  saveRDS(social_media_reshape_array, paste0(env$out_dir,'population_proxy/', 'model_data/', platform, '_md.rds'))
+  saveRDS(md, paste0(env$out_dir,'population_proxy/', 'model_data/', platform, '_md.rds'))
   saveRDS(n_obs_per_week, paste0(env$out_dir,'population_proxy/', 'model_data/', platform, '_md_missing.rds'))
 
   return(list('md'=social_media_reshape_array, 'md_missing'=n_obs_per_week))


### PR DESCRIPTION
See comments in #51 

There are two scripts to address the issue, both stored in src/1_pop_data:

[10_daily_audience.py](https://github.com/OxfordDemSci/UkraineNowPop/blob/51-prepare-facebook-and-instagram-data-for-n-mixture-model/src/1_pop_data/10_daily_audience.py)
it is now set to query one year of Facebook and Instagram data for the T_13Plus. Output is stored in 2023_WHO_Ukraine_Population\\output\\population_proxy\\social_media_audience\ua_[platform]_audience.csv.

[11_process_daily_audience.R](https://github.com/OxfordDemSci/UkraineNowPop/blob/51-prepare-facebook-and-instagram-data-for-n-mixture-model/src/1_pop_data/11_process_daily_audience.R)
It has a function to convert the audience into a 3d array [week, oblast, day_of_week].
The output for the models are stored in 2023_WHO_Ukraine_Population\\output\\population_proxy\\model_data\[platform]_md.rds.
It creates also a dataframe summarising missing observations per oblast, week and day of the week.
image.
I would advise to remove at least weeks that have less than one observation per oblast (n_obs).
It is stored in 2023_WHO_Ukraine_Population\\output\\population_proxy\\model_data\[platform]_md_missing.rds